### PR TITLE
support cpu count > 64

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -2373,7 +2373,13 @@ CpuSet::CpuSet()
     actual_cpu_count = (int)sysinfo.dwNumberOfProcessors;
 
     int group_count = get_processor_group_info();
+
+    #if defined (NCNN_TEST_FORCE_MULTI_GROUP)
+    legacy_mode = false;
+    // NCNN_LOGE("CpuSet::CpuSet force multi group mode");
+    #else
     legacy_mode = (actual_cpu_count < 64 && group_count == 1);
+    #endif
 }
 
 void CpuSet::enable(int cpu)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -2421,7 +2421,7 @@ void CpuSet::enable(int cpu)
     int group = cpu / (sizeof(ULONG_PTR) * 8);
     int bit = cpu % (sizeof(ULONG_PTR) * 8);
 
-    if (group <= NCNN_CPU_MASK_GROUPS)
+    if (group < NCNN_CPU_MASK_GROUPS)
     {
         mask_groups[group] |= ((ULONG_PTR)1 << bit);
     }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1681,22 +1681,6 @@ static int get_processor_group_info()
     return (int)GetActiveProcessorGroupCountPtr();
 }
 
-static int get_processors_in_group(int group)
-{
-    HMODULE kernel32 = GetModuleHandle(TEXT("kernel32.dll"));
-    if (!kernel32)
-        return 1; 
-    
-    typedef DWORD(WINAPI *GetActiveProcessorCountFunc)(WORD);
-    GetActiveProcessorCountFunc GetActiveProcessorCountPtr = 
-        (GetActiveProcessorCountFunc)GetProcAddress(kernel32, "GetActiveProcessorCount");
-    
-    if (!GetActiveProcessorCountPtr)
-        return 1; 
-    
-    return (int)GetActiveProcessorCountPtr((WORD)group);
-}
-
 #endif // defined _WIN32
 
 static void initialize_cpu_thread_affinity_mask(ncnn::CpuSet& mask_all, ncnn::CpuSet& mask_little, ncnn::CpuSet& mask_big)

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -7,9 +7,12 @@
 #include <stddef.h>
 
 #if defined _WIN32
+
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
 #ifndef NCNN_MAX_CPU_COUNT
+
     #ifdef NCNN_WINDOWS_SERVER
         #define NCNN_MAX_CPU_COUNT 4096 // Windows Server
     #elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
@@ -18,9 +21,12 @@
         #define NCNN_MAX_CPU_COUNT 256  // Windows 7+ Pro/Enterprise
     #else
         #define NCNN_MAX_CPU_COUNT 64   // Windows XP/2003
-    #endif
+    #endif // _WIN32_WINNT
+
 #endif // NCNN_MAX_CPU_COUNT
+
 #define NCNN_CPU_MASK_GROUPS ((NCNN_MAX_CPU_COUNT + sizeof(ULONG_PTR) * 8 - 1) / (sizeof(ULONG_PTR) * 8))
+
 #endif // _WIN32
 
 #if defined __ANDROID__ || defined __linux__

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -12,18 +12,16 @@
 #include <windows.h>
 
 #ifndef NCNN_MAX_CPU_COUNT
-
-    #ifdef NCNN_WINDOWS_SERVER
-        #define NCNN_MAX_CPU_COUNT 4096 // Windows Server
-    #elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
-        #define NCNN_MAX_CPU_COUNT 512  // Windows 10/11 Pro
-    #elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
-        #define NCNN_MAX_CPU_COUNT 256  // Windows 7+ Pro/Enterprise
-    #else
-        #define NCNN_MAX_CPU_COUNT 64   // Windows XP/2003
-    #endif // _WIN32_WINNT
-
-#endif // NCNN_MAX_CPU_COUNT
+#if defined(NCNN_WINDOWS_SERVER)
+#define NCNN_MAX_CPU_COUNT 4096
+#elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
+#define NCNN_MAX_CPU_COUNT 512
+#elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)
+#define NCNN_MAX_CPU_COUNT 256
+#else
+#define NCNN_MAX_CPU_COUNT 64
+#endif
+#endif
 
 #define NCNN_CPU_MASK_GROUPS ((NCNN_MAX_CPU_COUNT + sizeof(ULONG_PTR) * 8 - 1) / (sizeof(ULONG_PTR) * 8))
 
@@ -52,6 +50,7 @@ public:
     ULONG_PTR get_group_mask(int group) const;
     int get_group_count() const;
     bool is_legacy_mode() const;
+#endif // defined _WIN32
 
 public:
 #if defined _WIN32

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 
 ncnn_add_test(c_api)
 ncnn_add_test(cpu)
+ncnn_add_test(multicpu)
 ncnn_add_test(expression)
 ncnn_add_test(paramdict)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,15 @@ endif()
 
 ncnn_add_test(c_api)
 ncnn_add_test(cpu)
-ncnn_add_test(multicpu)
+
+if(WIN32)
+    target_compile_definitions(ncnn PUBLIC NCNN_TEST_FORCE_MULTI_GROUP)
+endif()
+add_executable(test_multicpu test_multicpu.cpp)
+target_link_libraries(test_multicpu PRIVATE ncnntestutil)
+add_test(NAME test_multicpu COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:test_multicpu> -P ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/run_test.cmake)
+set_property(TARGET test_multicpu PROPERTY FOLDER "tests")
+
 ncnn_add_test(expression)
 ncnn_add_test(paramdict)
 

--- a/tests/test_multicpu.cpp
+++ b/tests/test_multicpu.cpp
@@ -3,14 +3,14 @@
 #include <cassert>
 #include <vector>
 
-// 模拟测试函数 - 不需要真实的多CPU硬件
+// Test CpuSet - a class that simulates multi-CPU functionality
 void test_cpuset_basic_functionality()
 {
     std::cout << "=== Testing CpuSet Basic Functionality ===" << std::endl;
     
     ncnn::CpuSet cpuset;
     
-    // 测试基本启用/禁用
+    // Test enabling and disabling CPUs
     assert(!cpuset.is_enabled(0));
     cpuset.enable(0);
     assert(cpuset.is_enabled(0));
@@ -20,7 +20,7 @@ void test_cpuset_basic_functionality()
     assert(!cpuset.is_enabled(0));
     assert(cpuset.num_enabled() == 0);
     
-    std::cout << "✓ Basic enable/disable tests passed" << std::endl;
+    std::cout << "Basic enable/disable tests passed" << std::endl;
 }
 
 void test_cpuset_multi_group_simulation()
@@ -29,27 +29,35 @@ void test_cpuset_multi_group_simulation()
     
     ncnn::CpuSet cpuset;
     
-    // 模拟不同组的CPU（即使在单组系统上也能测试逻辑）
+#if defined (_WIN32) && !defined(NCNN_TEST_FORCE_MULTI_GROUP)
+    if (cpuset.is_legacy_mode())
+    {
+        std::cout << "Legacy mode detected, skipping multi-group tests" << std::endl;
+        return;
+    }
+#endif
+
+    // Simulate enabling CPUs across multiple groups
     std::vector<int> test_cpus = {0, 1, 32, 63, 64, 65, 96, 127, 128, 200, 256};
     
     for (int cpu : test_cpus) {
         cpuset.enable(cpu);
-        if (cpuset.is_enabled(cpu)) {
-            std::cout << "✓ CPU " << cpu << " enabled successfully" << std::endl;
-        } else {
-            std::cout << "⚠ CPU " << cpu << " could not be enabled (may be in legacy mode)" << std::endl;
-        }
+        assert(cpuset.is_enabled(cpu));
     }
     
     std::cout << "Total enabled CPUs: " << cpuset.num_enabled() << std::endl;
+    assert(cpuset.num_enabled() == (int)test_cpus.size());
     
-    // 测试组掩码功能
-    for (int group = 0; group < cpuset.get_group_count(); group++) {
-        ULONG_PTR mask = cpuset.get_group_mask(group);
-        if (mask != 0) {
-            std::cout << "✓ Group " << group << " has mask: 0x" << std::hex << mask << std::dec << std::endl;
-        }
-    }
+    // Test group masks
+#if defined (_WIN32)
+    assert(cpuset.get_group_mask(0) != 0);
+    assert(cpuset.get_group_mask(1) != 0);
+    assert(cpuset.get_group_mask(2) != 0);
+    assert(cpuset.get_group_mask(3) != 0);
+    assert(cpuset.get_group_mask(5) == 0);
+#endif 
+
+    std::cout << "Multi-group CPU simulation tests passed" << std::endl;
 }
 
 void test_cpuset_boundary_conditions()
@@ -58,20 +66,20 @@ void test_cpuset_boundary_conditions()
     
     ncnn::CpuSet cpuset;
     
-    // 测试组边界
+    // Test enabling CPUs at the boundary of groups
     std::vector<int> boundary_cpus = {63, 64, 127, 128, 191, 192, 255, 256};
     
     for (int cpu : boundary_cpus) {
         cpuset.enable(cpu);
         bool enabled = cpuset.is_enabled(cpu);
         std::cout << "CPU " << cpu << " (group boundary): " 
-                  << (enabled ? "✓ enabled" : "✗ not enabled") << std::endl;
+                  << (enabled ? "enabled" : "not enabled") << std::endl;
     }
     
-    // 测试disable_all
+    // Test disabling all CPUs
     cpuset.disable_all();
     assert(cpuset.num_enabled() == 0);
-    std::cout << "✓ disable_all() works correctly" << std::endl;
+    std::cout << "disable_all() works correctly" << std::endl;
 }
 
 void test_cpuset_edge_cases()
@@ -80,50 +88,22 @@ void test_cpuset_edge_cases()
     
     ncnn::CpuSet cpuset;
     
-    // 测试无效CPU编号
-    cpuset.enable(-1);  // 应该被忽略
-    cpuset.enable(5000); // 应该被忽略
+    // Test enabling out-of-bounds CPUs
+    cpuset.enable(-1);  // Should be ignored
+    cpuset.enable(5000); // Should be ignored
     assert(cpuset.num_enabled() == 0);
-    std::cout << "✓ Invalid CPU numbers handled correctly" << std::endl;
+    std::cout << "Invalid CPU numbers handled correctly" << std::endl;
     
-    // 测试重复启用
+    // Test duplicate enables
     cpuset.enable(10);
     cpuset.enable(10);
     assert(cpuset.num_enabled() == 1);
-    std::cout << "✓ Duplicate enable handled correctly" << std::endl;
+    std::cout << "Duplicate enable handled correctly" << std::endl;
     
-    // 测试禁用未启用的CPU
+    // Test disabling a non-enabled CPU
     cpuset.disable(20);
     assert(cpuset.num_enabled() == 1);
-    std::cout << "✓ Disabling non-enabled CPU handled correctly" << std::endl;
-}
-
-void test_performance_simulation()
-{
-    std::cout << "=== Testing Performance with Simulated Large CPU Count ===" << std::endl;
-    
-    auto start = std::chrono::high_resolution_clock::now();
-    
-    ncnn::CpuSet cpuset;
-    const int SIMULATION_CPU_COUNT = 1000; // 模拟1000个CPU
-    
-    // 大量操作性能测试
-    for (int i = 0; i < SIMULATION_CPU_COUNT; i++) {
-        cpuset.enable(i);
-    }
-    
-    // 检查性能
-    for (int i = 0; i < SIMULATION_CPU_COUNT; i++) {
-        cpuset.is_enabled(i);
-    }
-    
-    int enabled_count = cpuset.num_enabled();
-    
-    auto end = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    
-    std::cout << "✓ Processed " << SIMULATION_CPU_COUNT << " CPUs in " << duration.count() << " microseconds" << std::endl;
-    std::cout << "✓ Actually enabled: " << enabled_count << " CPUs" << std::endl;
+    std::cout << "Disabling non-enabled CPU handled correctly" << std::endl;
 }
 
 void test_real_system_integration()
@@ -135,15 +115,15 @@ void test_real_system_integration()
     
     ncnn::CpuSet cpuset;
     
-    // 启用所有真实CPU
+    // Enable all real CPUs
     for (int i = 0; i < real_cpu_count; i++) {
         cpuset.enable(i);
     }
     
     assert(cpuset.num_enabled() == real_cpu_count);
-    std::cout << "✓ All real CPUs enabled successfully" << std::endl;
+    std::cout << "All real CPUs enabled successfully" << std::endl;
     
-    // 测试线程亲和性掩码
+    // Test powersave modes
     const ncnn::CpuSet& all_mask = ncnn::get_cpu_thread_affinity_mask(0);
     const ncnn::CpuSet& little_mask = ncnn::get_cpu_thread_affinity_mask(1);
     const ncnn::CpuSet& big_mask = ncnn::get_cpu_thread_affinity_mask(2);
@@ -162,29 +142,28 @@ void test_processor_group_simulation()
 {
     std::cout << "=== Testing Processor Group Simulation ===" << std::endl;
     
-    // 模拟多处理器组的场景
+    // Simulate a system with multiple processor groups
     ncnn::CpuSet group0_cpus, group1_cpus, group2_cpus;
     
-    // 第一组：CPU 0-63
+    // First group: CPU 0-63
     for (int i = 0; i < 64; i++) {
         group0_cpus.enable(i);
     }
     
-    // 第二组：CPU 64-127  
+    // Second group：CPU 64-127
     for (int i = 64; i < 128; i++) {
         group1_cpus.enable(i);
     }
     
-    // 第三组：CPU 128-191
+    // Third group: CPU 128-191
     for (int i = 128; i < 192; i++) {
         group2_cpus.enable(i);
     }
     
-    std::cout << "✓ Group 0 CPUs: " << group0_cpus.num_enabled() << std::endl;
-    std::cout << "✓ Group 1 CPUs: " << group1_cpus.num_enabled() << std::endl; 
-    std::cout << "✓ Group 2 CPUs: " << group2_cpus.num_enabled() << std::endl;
+    std::cout << "Group 0 CPUs: " << group0_cpus.num_enabled() << std::endl;
+    std::cout << "Group 1 CPUs: " << group1_cpus.num_enabled() << std::endl; 
+    std::cout << "Group 2 CPUs: " << group2_cpus.num_enabled() << std::endl;
     
-    // 验证组掩码
     #if defined _WIN32
     for (int group = 0; group < 3; group++) {
         ncnn::CpuSet* test_set = (group == 0) ? &group0_cpus : 
@@ -216,20 +195,17 @@ int main()
         test_cpuset_edge_cases();
         std::cout << std::endl;
         
-        test_performance_simulation();
-        std::cout << std::endl;
-        
         test_real_system_integration();
         std::cout << std::endl;
         
         test_processor_group_simulation();
         std::cout << std::endl;
         
-        std::cout << "🎉 All simulation tests passed!" << std::endl;
+        std::cout << "All simulation tests passed!" << std::endl;
         return 0;
         
     } catch (const std::exception& e) {
-        std::cerr << "❌ Test failed: " << e.what() << std::endl;
+        std::cerr << "Test failed: " << e.what() << std::endl;
         return 1;
     }
 }

--- a/tests/test_multicpu.cpp
+++ b/tests/test_multicpu.cpp
@@ -1,0 +1,235 @@
+#include "../src/cpu.h"
+#include <iostream>
+#include <cassert>
+#include <vector>
+
+// 模拟测试函数 - 不需要真实的多CPU硬件
+void test_cpuset_basic_functionality()
+{
+    std::cout << "=== Testing CpuSet Basic Functionality ===" << std::endl;
+    
+    ncnn::CpuSet cpuset;
+    
+    // 测试基本启用/禁用
+    assert(!cpuset.is_enabled(0));
+    cpuset.enable(0);
+    assert(cpuset.is_enabled(0));
+    assert(cpuset.num_enabled() == 1);
+    
+    cpuset.disable(0);
+    assert(!cpuset.is_enabled(0));
+    assert(cpuset.num_enabled() == 0);
+    
+    std::cout << "✓ Basic enable/disable tests passed" << std::endl;
+}
+
+void test_cpuset_multi_group_simulation()
+{
+    std::cout << "=== Testing Multi-Group CPU Simulation ===" << std::endl;
+    
+    ncnn::CpuSet cpuset;
+    
+    // 模拟不同组的CPU（即使在单组系统上也能测试逻辑）
+    std::vector<int> test_cpus = {0, 1, 32, 63, 64, 65, 96, 127, 128, 200, 256};
+    
+    for (int cpu : test_cpus) {
+        cpuset.enable(cpu);
+        if (cpuset.is_enabled(cpu)) {
+            std::cout << "✓ CPU " << cpu << " enabled successfully" << std::endl;
+        } else {
+            std::cout << "⚠ CPU " << cpu << " could not be enabled (may be in legacy mode)" << std::endl;
+        }
+    }
+    
+    std::cout << "Total enabled CPUs: " << cpuset.num_enabled() << std::endl;
+    
+    // 测试组掩码功能
+    for (int group = 0; group < cpuset.get_group_count(); group++) {
+        ULONG_PTR mask = cpuset.get_group_mask(group);
+        if (mask != 0) {
+            std::cout << "✓ Group " << group << " has mask: 0x" << std::hex << mask << std::dec << std::endl;
+        }
+    }
+}
+
+void test_cpuset_boundary_conditions()
+{
+    std::cout << "=== Testing Boundary Conditions ===" << std::endl;
+    
+    ncnn::CpuSet cpuset;
+    
+    // 测试组边界
+    std::vector<int> boundary_cpus = {63, 64, 127, 128, 191, 192, 255, 256};
+    
+    for (int cpu : boundary_cpus) {
+        cpuset.enable(cpu);
+        bool enabled = cpuset.is_enabled(cpu);
+        std::cout << "CPU " << cpu << " (group boundary): " 
+                  << (enabled ? "✓ enabled" : "✗ not enabled") << std::endl;
+    }
+    
+    // 测试disable_all
+    cpuset.disable_all();
+    assert(cpuset.num_enabled() == 0);
+    std::cout << "✓ disable_all() works correctly" << std::endl;
+}
+
+void test_cpuset_edge_cases()
+{
+    std::cout << "=== Testing Edge Cases ===" << std::endl;
+    
+    ncnn::CpuSet cpuset;
+    
+    // 测试无效CPU编号
+    cpuset.enable(-1);  // 应该被忽略
+    cpuset.enable(5000); // 应该被忽略
+    assert(cpuset.num_enabled() == 0);
+    std::cout << "✓ Invalid CPU numbers handled correctly" << std::endl;
+    
+    // 测试重复启用
+    cpuset.enable(10);
+    cpuset.enable(10);
+    assert(cpuset.num_enabled() == 1);
+    std::cout << "✓ Duplicate enable handled correctly" << std::endl;
+    
+    // 测试禁用未启用的CPU
+    cpuset.disable(20);
+    assert(cpuset.num_enabled() == 1);
+    std::cout << "✓ Disabling non-enabled CPU handled correctly" << std::endl;
+}
+
+void test_performance_simulation()
+{
+    std::cout << "=== Testing Performance with Simulated Large CPU Count ===" << std::endl;
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    
+    ncnn::CpuSet cpuset;
+    const int SIMULATION_CPU_COUNT = 1000; // 模拟1000个CPU
+    
+    // 大量操作性能测试
+    for (int i = 0; i < SIMULATION_CPU_COUNT; i++) {
+        cpuset.enable(i);
+    }
+    
+    // 检查性能
+    for (int i = 0; i < SIMULATION_CPU_COUNT; i++) {
+        cpuset.is_enabled(i);
+    }
+    
+    int enabled_count = cpuset.num_enabled();
+    
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    
+    std::cout << "✓ Processed " << SIMULATION_CPU_COUNT << " CPUs in " << duration.count() << " microseconds" << std::endl;
+    std::cout << "✓ Actually enabled: " << enabled_count << " CPUs" << std::endl;
+}
+
+void test_real_system_integration()
+{
+    std::cout << "=== Testing Integration with Real System ===" << std::endl;
+    
+    int real_cpu_count = ncnn::get_cpu_count();
+    std::cout << "Real system CPU count: " << real_cpu_count << std::endl;
+    
+    ncnn::CpuSet cpuset;
+    
+    // 启用所有真实CPU
+    for (int i = 0; i < real_cpu_count; i++) {
+        cpuset.enable(i);
+    }
+    
+    assert(cpuset.num_enabled() == real_cpu_count);
+    std::cout << "✓ All real CPUs enabled successfully" << std::endl;
+    
+    // 测试线程亲和性掩码
+    const ncnn::CpuSet& all_mask = ncnn::get_cpu_thread_affinity_mask(0);
+    const ncnn::CpuSet& little_mask = ncnn::get_cpu_thread_affinity_mask(1);
+    const ncnn::CpuSet& big_mask = ncnn::get_cpu_thread_affinity_mask(2);
+    
+    std::cout << "All cores enabled: " << all_mask.num_enabled() << std::endl;
+    std::cout << "Little cores enabled: " << little_mask.num_enabled() << std::endl;
+    std::cout << "Big cores enabled: " << big_mask.num_enabled() << std::endl;
+    
+    #if defined _WIN32
+    std::cout << "Legacy mode: " << (cpuset.is_legacy_mode() ? "Yes" : "No") << std::endl;
+    std::cout << "Group count: " << cpuset.get_group_count() << std::endl;
+    #endif
+}
+
+void test_processor_group_simulation()
+{
+    std::cout << "=== Testing Processor Group Simulation ===" << std::endl;
+    
+    // 模拟多处理器组的场景
+    ncnn::CpuSet group0_cpus, group1_cpus, group2_cpus;
+    
+    // 第一组：CPU 0-63
+    for (int i = 0; i < 64; i++) {
+        group0_cpus.enable(i);
+    }
+    
+    // 第二组：CPU 64-127  
+    for (int i = 64; i < 128; i++) {
+        group1_cpus.enable(i);
+    }
+    
+    // 第三组：CPU 128-191
+    for (int i = 128; i < 192; i++) {
+        group2_cpus.enable(i);
+    }
+    
+    std::cout << "✓ Group 0 CPUs: " << group0_cpus.num_enabled() << std::endl;
+    std::cout << "✓ Group 1 CPUs: " << group1_cpus.num_enabled() << std::endl; 
+    std::cout << "✓ Group 2 CPUs: " << group2_cpus.num_enabled() << std::endl;
+    
+    // 验证组掩码
+    #if defined _WIN32
+    for (int group = 0; group < 3; group++) {
+        ncnn::CpuSet* test_set = (group == 0) ? &group0_cpus : 
+                                (group == 1) ? &group1_cpus : &group2_cpus;
+        ULONG_PTR mask = test_set->get_group_mask(group);
+        std::cout << "Group " << group << " mask: 0x" << std::hex << mask << std::dec << std::endl;
+    }
+    #endif
+}
+
+int main()
+{
+    std::cout << "Starting CpuSet Multi-CPU Simulation Tests..." << std::endl;
+    std::cout << "Current system CPU count: " << ncnn::get_cpu_count() << std::endl;
+    std::cout << "NCNN_MAX_CPU_COUNT: " << NCNN_MAX_CPU_COUNT << std::endl;
+    std::cout << "NCNN_CPU_MASK_GROUPS: " << NCNN_CPU_MASK_GROUPS << std::endl;
+    std::cout << std::endl;
+    
+    try {
+        test_cpuset_basic_functionality();
+        std::cout << std::endl;
+        
+        test_cpuset_multi_group_simulation();
+        std::cout << std::endl;
+        
+        test_cpuset_boundary_conditions();
+        std::cout << std::endl;
+        
+        test_cpuset_edge_cases();
+        std::cout << std::endl;
+        
+        test_performance_simulation();
+        std::cout << std::endl;
+        
+        test_real_system_integration();
+        std::cout << std::endl;
+        
+        test_processor_group_simulation();
+        std::cout << std::endl;
+        
+        std::cout << "🎉 All simulation tests passed!" << std::endl;
+        return 0;
+        
+    } catch (const std::exception& e) {
+        std::cerr << "❌ Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
对于**Win**平台：
使用多组掩码方案，每组默认为64。根据Windows系统版本设置最大CPU支持数
生产环境中，`group = 1`（cpu count <= 64）的情况下，使用`legacy mode`，保留原始逻辑

- 缺憾：在`group > 1`（cpu count > 64)的情况下，假定了每组的性能以及功能相同，未区分大小核

新增单元测试：test_multicpu，在测试环境中，屏蔽 `legacy mode` 强制使用 group 逻辑，验证多组掩码的逻辑功能

对于**Linux/Android**平台：
未作修改。
`cpu_set_t` 的大小，在现代主流实现（如 glibc）默认通过 CPU_SETSIZE 定义为 ​1024。即原生支持 cpu count > 64
如想支持 > 1024，可使用 `cpu_set_t*` 加上带有`_S` POSIX指令实现

对于**Apple**平台：
未作修改。
`unsigned int`最高支持32核，考虑到Apple目前没有超过32核的芯片，为了面向未来的健壮性，可改用`uint64_t`以支持64 cpu

其余单元测试结果与主分支一致

**修改文件**
src/cpu.cpp
src/cpu.h
tests/CMakeList.txt

**新增文件**
tests/test_multicpu.cpp